### PR TITLE
Fix localhost port

### DIFF
--- a/condition.html
+++ b/condition.html
@@ -83,7 +83,7 @@
             try { 
                 const workspace = window.location.href.split('/workspaces/')[1].split('/')[0];
                 const isLocal = (window.location.href.indexOf("localhost") != -1);
-                const backendBaseURL = isLocal ? window.location.protocol + "//" + window.location.host + "/core/rest" 
+                const backendBaseURL = isLocal ? window.location.protocol + "//" + window.location.hostname + ":8080/core/rest" 
                                                 : window.location.protocol + "//rest." + window.location.hostname + "/core/rest";
             
                 publishedModelURL = `${backendBaseURL}/workspaces/${workspace}/trained-models?published=true`;


### PR DESCRIPTION
The rest endpoint is usually hosted on port 8080 when running locally, unlike the webserver itself (which is usually on port 4000).